### PR TITLE
Fix missing npm build script

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=development nodemon src/index.js",
     "start": "node src/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "echo 'No build step for server'",
+    "vercel-build": "npm run build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Add no-op `build` and `vercel-build` scripts to `server/package.json` to fix Vercel deployment error due to missing build script.

---
<a href="https://cursor.com/background-agent?bcId=bc-25f60c78-d140-421c-9a2c-3acdcc14739b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25f60c78-d140-421c-9a2c-3acdcc14739b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

